### PR TITLE
Remove param reassignment

### DIFF
--- a/lib/getComment.js
+++ b/lib/getComment.js
@@ -1,17 +1,13 @@
-module.exports = getComment
-
 function getComment (comment, defaultComment) {
+  // set comment to default if none passed it
+  const eventComment = (!comment) ? defaultComment : comment
+
   // comment can be either a string or an array
-
-  if (!comment) {
-    comment = defaultComment
-  }
-
-  if (typeof comment === 'string' || comment instanceof String) {
-    return comment
+  if (typeof eventComment === 'string' || eventComment instanceof String) {
+    return eventComment
   } else {
     const pos = getRandomInt(0, comment.length)
-    return comment[pos] || defaultComment
+    return eventComment[pos] || defaultComment
   }
 }
 
@@ -23,3 +19,5 @@ function getRandomInt (min, max) {
   max = Math.floor(max)
   return Math.floor(Math.random() * (max - min)) + min
 }
+
+module.exports = getComment

--- a/lib/getComment.js
+++ b/lib/getComment.js
@@ -1,6 +1,6 @@
 function getComment (comment, defaultComment) {
   // set comment to default if none passed it
-  const eventComment = (!comment) ? defaultComment : comment
+  const eventComment = comment || defaultComment
 
   // comment can be either a string or an array
   if (typeof eventComment === 'string' || eventComment instanceof String) {


### PR DESCRIPTION
Changes `getComment` so that parameters are no longer reassigned, bc assignment to variables declared as function parameters can be misleading and lead to confusing behavior, as modifying function parameters will also mutate the `arguments` object.

/cc @hiimbex 