### PR TITLE
Fix docs for filtering based on issue type

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ requestInfoLabelToAdd: needs-more-info
 
 # *OPTIONAL* Only warn about insufficient information on these events type
 # Keys must be lowercase. Valid values are 'issue' and 'pullRequest'
-requestInfoLabelToAdd:
+requestInfoOn:
   pullRequest: true
   issue: true
 


### PR DESCRIPTION
This was added in #13, but the incorrect key was added to the docs in the README.