### PR TITLE
Update request-info to require Probot v7.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const getConfig = require('probot-config')
 
 module.exports = app => {
   app.on('installation_repositories.added', learningLabWelcome)
-  app.on(['pull_request.opened', 'issues.opened'], receive)G
+  app.on(['pull_request.opened', 'issues.opened'], receive)
   async function receive (context) {
     let title
     let body

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const defaultConfig = require('./lib/defaultConfig')
 const PullRequestBodyChecker = require('./lib/PullRequestBodyChecker')
 const getConfig = require('probot-config')
 
-module.exports = robot => {
-  robot.on(['pull_request.opened', 'issues.opened'], receive)
+module.exports = app => {
+  app.on(['pull_request.opened', 'issues.opened'], receive)
   async function receive (context) {
     let title
     let body

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,46 +5,57 @@
     "requires": true,
     "dependencies": {
         "@octokit/rest": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.9.4.tgz",
-            "integrity": "sha512-v3CS1qW4IjriMvGgm4lDnYFBJlkwvzIbTxiipOcwVP8xeK8ih2pJofRhk7enmLngTtNEa+sIApJNkXxyyDKqLg==",
+            "version": "15.13.0",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.13.0.tgz",
+            "integrity": "sha512-zgsrqMCLcv4XqpT0QGUykHTvKo33aCVzXP86Bq6HmeKuwY6hEWJ+AVCeL/m3bXk1JBpLyBgzjJDfWEfZcqsR6g==",
             "requires": {
                 "before-after-hook": "1.1.0",
                 "btoa-lite": "1.0.0",
-                "debug": "3.1.0",
+                "debug": "3.2.5",
                 "http-proxy-agent": "2.1.0",
                 "https-proxy-agent": "2.2.1",
                 "lodash": "4.17.4",
-                "node-fetch": "2.1.2",
+                "node-fetch": "2.2.0",
+                "universal-user-agent": "2.0.1",
                 "url-template": "2.0.8"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "2.1.1"
                     }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
                 }
             }
         },
         "@octokit/webhooks": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-3.1.1.tgz",
-            "integrity": "sha512-VqpGDClqhLw5sKV+or5AnkPmUyur/Oktr9paqiR+yH69Tew9QA/vXHjKP4zctxj5PVAsOdTQFhSzP53qbNLVOg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-5.0.2.tgz",
+            "integrity": "sha512-htxI5cNiaEOlJbero6akw8bVZm3maN7LtCZbczxJQko3NvQqiROmzryE39+FnaoaHkQr6IAOx2JnPBZlkPHnVQ==",
             "requires": {
                 "buffer-equal-constant-time": "1.0.1",
-                "debug": "3.1.0"
+                "debug": "4.0.1"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.0.1.tgz",
+                    "integrity": "sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==",
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "2.1.1"
                     }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
                 }
             }
         },
@@ -281,7 +292,7 @@
         },
         "async": {
             "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "async-each": {
@@ -427,9 +438,9 @@
             }
         },
         "bottleneck": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.6.0.tgz",
-            "integrity": "sha512-3fgu36UohvqOzv4aYPFyUR39LckOcA5cM4Yxija/V9Effd7a/22tFtZga89t3rSNtqEqo0bMT8IhCFztD7d/8A=="
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.11.2.tgz",
+            "integrity": "sha512-rC2HVbtSaTgFsrnW3nkODmSHSGewyGVGeIN1HlOsFhgiRu0hrJqQu1m1icRYlc1L7Jg4Sz62bj/2EynY5HcqMA=="
         },
         "boxen": {
             "version": "1.3.0",
@@ -1170,9 +1181,9 @@
             }
         },
         "dotenv": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-            "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
+            "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
         },
         "dtrace-provider": {
             "version": "0.8.7",
@@ -1280,16 +1291,16 @@
             }
         },
         "es6-promise": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-            "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+            "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
         },
         "es6-promisify": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
             "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
             "requires": {
-                "es6-promise": "4.2.4"
+                "es6-promise": "4.2.5"
             }
         },
         "es6-set": {
@@ -1675,7 +1686,7 @@
         },
         "express": {
             "version": "4.16.3",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+            "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
             "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
             "requires": {
                 "accepts": "1.3.5",
@@ -1697,7 +1708,7 @@
                 "on-finished": "2.3.0",
                 "parseurl": "1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "2.0.3",
+                "proxy-addr": "2.0.4",
                 "qs": "6.5.1",
                 "range-parser": "1.2.0",
                 "safe-buffer": "5.1.1",
@@ -1721,9 +1732,9 @@
             }
         },
         "express-async-errors": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-2.1.2.tgz",
-            "integrity": "sha512-irtoGiU0TGf8XNpPPndzGaOkcxX0Hue3jGoEBJCCk88uKNOp2y43Gvc7hTzf+0nilBK1ucLYdIIyWSscHHWTGA=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.0.0.tgz",
+            "integrity": "sha512-voLFcOahCxhY8v1EIrM2snaOMHWcB+F2SJWTWPmc2VmK5z/TmU++01ANae4BAjBT+Dbr9k929OV1EFkuSOsACA=="
         },
         "extend": {
             "version": "3.0.1",
@@ -1874,7 +1885,7 @@
         },
         "finalhandler": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+            "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
             "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
             "requires": {
                 "debug": "2.6.9",
@@ -2643,7 +2654,7 @@
         },
         "handlebars": {
             "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+            "resolved": "http://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
             "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
             "requires": {
                 "async": "1.5.2",
@@ -2725,7 +2736,7 @@
         },
         "http-errors": {
             "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "requires": {
                 "depd": "1.1.2",
@@ -2759,16 +2770,21 @@
             "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
             "requires": {
                 "agent-base": "4.2.1",
-                "debug": "3.1.0"
+                "debug": "3.2.5"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "2.1.1"
                     }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
                 }
             }
         },
@@ -2849,9 +2865,9 @@
             "dev": true
         },
         "ipaddr.js": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
-            "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+            "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
@@ -2875,6 +2891,11 @@
             "requires": {
                 "is-callable": "1.1.3"
             }
+        },
+        "is-base64": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-0.0.5.tgz",
+            "integrity": "sha512-eRLie1GvKWp5Hab3x0uZXOvxrlw72elV2qEcvrNeoqNv6W30BjyvdiEqouaIrU3qh5KWRlxJp7iDLipA/hNOsA=="
         },
         "is-binary-path": {
             "version": "1.0.1",
@@ -3458,6 +3479,11 @@
                 "yallist": "2.1.2"
             }
         },
+        "macos-release": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+            "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
+        },
         "make-dir": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -3742,7 +3768,7 @@
                 },
                 "rimraf": {
                     "version": "2.4.5",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                    "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
                     "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                     "optional": true,
                     "requires": {
@@ -3792,7 +3818,7 @@
         },
         "ncp": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
             "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
             "optional": true
         },
@@ -3802,9 +3828,9 @@
             "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
         },
         "node-fetch": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-            "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+            "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
         },
         "nodemon": {
             "version": "1.18.1",
@@ -4049,6 +4075,15 @@
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
+        "os-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+            "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+            "requires": {
+                "macos-release": "1.1.0",
+                "win-release": "1.1.1"
+            }
+        },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -4250,35 +4285,39 @@
             "dev": true
         },
         "probot": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/probot/-/probot-6.2.1.tgz",
-            "integrity": "sha512-RhP8vSefnzD+Erb/5DGl9TMV3r38D56GmSqMKf5O1bCuc+ySC8246yKxNXYRxjmarXejlg/Q4raCmRSo4s5HPA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/probot/-/probot-7.2.0.tgz",
+            "integrity": "sha512-bVNJ174eWOUvPSrAOCflzvbS4XgfS9t32I2uGy256IwMl7Q6SZt/MZ8hg3FrK/bHb9q40F74MB7ODZ1mimhKjA==",
             "requires": {
-                "@octokit/rest": "15.9.4",
-                "@octokit/webhooks": "3.1.1",
-                "bottleneck": "2.6.0",
+                "@octokit/rest": "15.13.0",
+                "@octokit/webhooks": "5.0.2",
+                "bottleneck": "2.11.2",
                 "bunyan": "1.8.12",
                 "bunyan-format": "0.2.1",
                 "bunyan-sentry-stream": "1.2.1",
                 "cache-manager": "2.9.0",
-                "commander": "2.16.0",
-                "dotenv": "5.0.1",
+                "commander": "2.18.0",
+                "dotenv": "6.0.0",
                 "express": "4.16.3",
-                "express-async-errors": "2.1.2",
+                "express-async-errors": "3.0.0",
                 "hbs": "4.0.1",
+                "is-base64": "0.0.5",
                 "js-yaml": "3.12.0",
                 "jsonwebtoken": "8.3.0",
                 "pkg-conf": "2.0.0",
                 "promise-events": "0.1.4",
-                "raven": "2.6.3",
+                "qs": "6.5.2",
+                "raven": "2.6.4",
                 "resolve": "1.8.1",
-                "semver": "5.5.0"
+                "semver": "5.5.1",
+                "update-dotenv": "1.1.0",
+                "uuid": "3.3.2"
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.16.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
-                    "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
+                    "version": "2.18.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
+                    "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ=="
                 },
                 "esprima": {
                     "version": "4.0.1",
@@ -4294,6 +4333,11 @@
                         "esprima": "4.0.1"
                     }
                 },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+                },
                 "resolve": {
                     "version": "1.8.1",
                     "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -4303,9 +4347,9 @@
                     }
                 },
                 "semver": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+                    "version": "5.5.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+                    "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
                 }
             }
         },
@@ -4351,12 +4395,12 @@
             "integrity": "sha1-PIj66X5EjaaPf88Z1O4wjW5DLVs="
         },
         "proxy-addr": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-            "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+            "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
             "requires": {
                 "forwarded": "0.1.2",
-                "ipaddr.js": "1.6.0"
+                "ipaddr.js": "1.8.0"
             }
         },
         "ps-tree": {
@@ -4399,15 +4443,15 @@
             "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
         },
         "raven": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.3.tgz",
-            "integrity": "sha512-bKre7qlDW+y1+G2bUtCuntdDYc8o5v1T233t0vmJfbj8ttGOgLrGRlYB8saelVMW9KUAJNLrhFkAKOwFWFJonw==",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
+            "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
             "requires": {
                 "cookie": "0.3.1",
                 "md5": "2.2.1",
                 "stack-trace": "0.0.10",
                 "timed-out": "4.0.1",
-                "uuid": "3.0.0"
+                "uuid": "3.3.2"
             }
         },
         "raw-body": {
@@ -4695,8 +4739,7 @@
         "semver": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-            "dev": true
+            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         },
         "semver-diff": {
             "version": "2.1.0",
@@ -5499,6 +5542,14 @@
                 "crypto-random-string": "1.0.0"
             }
         },
+        "universal-user-agent": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.1.tgz",
+            "integrity": "sha512-vz+heWVydO0iyYAa65VHD7WZkYzhl7BeNVy4i54p4TF8OMiLSXdbuQe4hm+fmWAsL+rVibaQHXfhvkw3c1Ws2w==",
+            "requires": {
+                "os-name": "2.0.1"
+            }
+        },
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -5555,6 +5606,11 @@
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
             "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
             "dev": true
+        },
+        "update-dotenv": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/update-dotenv/-/update-dotenv-1.1.0.tgz",
+            "integrity": "sha512-37KqjTZTJoXGQI6iI6PNo9lRsBHNtisBISyDCYLrR0hf2YlQo0Gw18v6DXseWk7kWJr33sHh5sMP78ofzbd/ag=="
         },
         "update-notifier": {
             "version": "2.5.0",
@@ -5662,9 +5718,9 @@
             "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
         },
         "uuid": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
-            "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "validate-npm-package-license": {
             "version": "3.0.1",
@@ -5746,6 +5802,14 @@
                 }
             }
         },
+        "win-release": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+            "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+            "requires": {
+                "semver": "5.3.0"
+            }
+        },
         "window-size": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -5802,7 +5866,7 @@
         },
         "yargs": {
             "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+            "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
             "optional": true,
             "requires": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "npm": ">= 5.3.0"
     },
     "dependencies": {
-        "probot": "^6.0.0",
+        "probot": "^7.2.0",
         "probot-config": "^0.2.0"
     }
 }

--- a/test/events/issueFailEvent.json
+++ b/test/events/issueFailEvent.json
@@ -1,5 +1,5 @@
 {
-    "event": "issues", 
+    "name": "issues",
     "payload": {
       "action": "opened",
       "issue": {

--- a/test/events/issueSuccessEvent.json
+++ b/test/events/issueSuccessEvent.json
@@ -1,5 +1,5 @@
 {
-    "event": "issues", 
+    "name": "issues",
     "payload": {
       "action": "opened",
       "issue": {

--- a/test/events/prFailEvent.json
+++ b/test/events/prFailEvent.json
@@ -1,5 +1,5 @@
 {
-    "event": "issues",
+    "name": "issues",
     "payload": {
       "action": "opened",
       "pull_request": {

--- a/test/events/prSuccessEvent.json
+++ b/test/events/prSuccessEvent.json
@@ -1,5 +1,5 @@
 {
-    "event": "issues",
+    "name": "issues",
     "payload": {
       "action": "opened",
       "pull_request": {

--- a/test/events/prTemplateBodyEvent.json
+++ b/test/events/prTemplateBodyEvent.json
@@ -1,5 +1,5 @@
 {
-  "event": "issues",
+  "name": "issues",
   "payload": {
     "action": "opened",
     "pull_request": {

--- a/test/index.js
+++ b/test/index.js
@@ -343,13 +343,13 @@ describe('Request info', () => {
     })
 
     it('opens a new issue', async () => {
-      await robot.receive(event)
+      await app.receive(event)
       expect(github.issues.createComment).toHaveBeenCalled()
     })
 
     it('does not open a new issue if the repo name is not right', async () => {
       event.payload.repositories_added = [{ name: 'NOT-introduction-to-github-apps' }]
-      await robot.receive(event)
+      await app.receive(event)
       expect(github.issues.createComment).toNotHaveBeenCalled()
     })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -8,12 +8,12 @@ const prFailEvent = require('./events/prFailEvent')
 const prTemplateBodyEvent = require('./events/prTemplateBodyEvent')
 
 describe('Request info', () => {
-  let robot
+  let app
   let github
 
   beforeEach(() => {
-    robot = new Application()
-    plugin(robot)
+    app = new Application()
+    plugin(app)
 
     github = {
       repos: {
@@ -28,13 +28,13 @@ describe('Request info', () => {
         addLabels: expect.createSpy()
       }
     }
-    robot.auth = () => Promise.resolve(github)
+    app.auth = () => Promise.resolve(github)
   })
 
   describe('Request info on both issues and pull requests', () => {
     describe('Posts a comment because...', () => {
       it('there wasn\'t enough info provided in an issue', async () => {
-        await robot.receive(issueSuccessEvent)
+        await app.receive(issueSuccessEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -49,7 +49,7 @@ describe('Request info', () => {
 
     describe('Posts a comment because...', () => {
       it('there wasn\'t enough info provided in a pull request', async () => {
-        await robot.receive(prSuccessEvent)
+        await app.receive(prSuccessEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -64,7 +64,7 @@ describe('Request info', () => {
 
     describe('Does not post a comment because...', () => {
       it('there was a body in issue', async () => {
-        await robot.receive(issueFailEvent)
+        await app.receive(issueFailEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -89,7 +89,7 @@ describe('Request info', () => {
 
     describe('Does not post a comment because...', () => {
       it("'issue' type is disabled even if there wasn't enough info provided", async () => {
-        await robot.receive(issueSuccessEvent)
+        await app.receive(issueSuccessEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -104,7 +104,7 @@ describe('Request info', () => {
 
     describe('Does not post a comment because...', () => {
       it('there was a body in issue', async () => {
-        await robot.receive(issueFailEvent)
+        await app.receive(issueFailEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -119,7 +119,7 @@ describe('Request info', () => {
 
     describe('Posts a comment because...', () => {
       it('there wasn\'t enough info provided in a pull request', async () => {
-        await robot.receive(prSuccessEvent)
+        await app.receive(prSuccessEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -144,7 +144,7 @@ describe('Request info', () => {
 
     describe('Does not post a comment because...', () => {
       it("'pullRequest' type is disabled even if there wasn't enough info provided", async () => {
-        await robot.receive(prSuccessEvent)
+        await app.receive(prSuccessEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -159,7 +159,7 @@ describe('Request info', () => {
 
     describe('Does not post a comment because...', () => {
       it('there was a body in pr', async () => {
-        await robot.receive(prFailEvent)
+        await app.receive(prFailEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -174,7 +174,7 @@ describe('Request info', () => {
 
     describe('Posts a comment because...', () => {
       it('there wasn\'t enough info provided (issue type still working)', async () => {
-        await robot.receive(issueSuccessEvent)
+        await app.receive(issueSuccessEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -199,7 +199,7 @@ describe('Request info', () => {
 
     describe('Posts a random comment', () => {
       it('selects a random comment and posts it', async () => {
-        await robot.receive(prSuccessEvent)
+        await app.receive(prSuccessEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -224,7 +224,7 @@ describe('Request info', () => {
 
     describe('Posts a random comment', () => {
       it('selects a random comment and posts it', async () => {
-        await robot.receive(prSuccessEvent)
+        await app.receive(prSuccessEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -259,7 +259,7 @@ describe('Request info', () => {
       })
 
       it('Posts a comment when PR body is equal to template', async () => {
-        await robot.receive(prTemplateBodyEvent)
+        await app.receive(prTemplateBodyEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -271,7 +271,7 @@ describe('Request info', () => {
       })
 
       it('Does not post a comment when PR body is different from template', async () => {
-        await robot.receive(prFailEvent)
+        await app.receive(prFailEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -303,7 +303,7 @@ describe('Request info', () => {
       })
 
       it('Does not post a comment when PR body is equal to template', async () => {
-        await robot.receive(prTemplateBodyEvent)
+        await app.receive(prTemplateBodyEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',
@@ -315,7 +315,7 @@ describe('Request info', () => {
       })
 
       it('Does not post a comment when PR body is different from template', async () => {
-        await robot.receive(prFailEvent)
+        await app.receive(prFailEvent)
 
         expect(github.repos.getContent).toHaveBeenCalledWith({
           owner: 'hiimbex',

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 const expect = require('expect')
-const {createRobot} = require('probot')
+const {Application} = require('probot')
 const plugin = require('..')
 const issueSuccessEvent = require('./events/issueSuccessEvent')
 const issueFailEvent = require('./events/issueFailEvent')
@@ -12,7 +12,7 @@ describe('Request info', () => {
   let github
 
   beforeEach(() => {
-    robot = createRobot()
+    robot = new Application()
     plugin(robot)
 
     github = {


### PR DESCRIPTION
Updating request-info as per the [Updating Probot](https://github.com/behaviorbot/welcome/issues/15) issue in [welcome](https://github.com/behaviorbot/welcome) opened by @hiimbex. 😄 

This PR will
- update the `package.json` to require Probot v7.2.0 or higher
- update tests and mock payload to reflect changes in the new major version of Probot
